### PR TITLE
Connecting CLEAR_GRID action to mazeReducer to actually clear maze

### DIFF
--- a/src/models/maze/initialState.ts
+++ b/src/models/maze/initialState.ts
@@ -1,34 +1,65 @@
-import { MazeState } from './';
+import { MazeState } from "./";
 
 export const initialState: MazeState = {
   mazeInfo: {
     0: [
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'startpoint', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false }
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "startpoint", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false }
     ],
     1: [
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false }
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false }
     ],
     2: [
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false }
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false }
     ],
     3: [
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'endpoint', visited: false },
-      { type: 'wall', visited: false },
-      { type: 'wall', visited: false }
+      { type: "wall", visited: false },
+      { type: "wall", visited: false },
+      { type: "endpoint", visited: false },
+      { type: "wall", visited: false },
+      { type: "wall", visited: false }
     ]
   }
+};
+
+export const clearMaze: MazeState["mazeInfo"] = {
+  0: [
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false }
+  ],
+  1: [
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false }
+  ],
+  2: [
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false }
+  ],
+  3: [
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false },
+    { type: "wall", visited: false }
+  ]
 };

--- a/src/reducers/mazeReducer.spec.ts
+++ b/src/reducers/mazeReducer.spec.ts
@@ -1,0 +1,18 @@
+import { mazeReducer } from "./mazeReducer";
+import { CLEAR_GRID } from "../actions/navbarActions";
+import { initialState, clearMaze } from "../models/maze/initialState";
+import { MazeState } from "../models/maze";
+
+describe("Maze Reducer Tests", () => {
+  it("Clear Grid Expected State", () => {
+    const action = {
+      type: CLEAR_GRID,
+      payload: null
+    };
+
+    const updatedState = mazeReducer(initialState, action);
+    const expectedState: MazeState = { ...initialState, mazeInfo: clearMaze };
+
+    expect(updatedState).toEqual(expectedState);
+  });
+});

--- a/src/reducers/mazeReducer.ts
+++ b/src/reducers/mazeReducer.ts
@@ -1,11 +1,17 @@
-import { MazeState } from '../models/maze';
-import { initialState } from '../models/maze/initialState';
+import { MazeState } from "../models/maze";
+import { initialState, clearMaze } from "../models/maze/initialState";
+import { CLEAR_GRID } from "../actions/navbarActions";
 
 export const mazeReducer = (
   state: MazeState = initialState,
   { type, payload }: any
 ) => {
   switch (type) {
+    case CLEAR_GRID:
+      return {
+        ...state,
+        mazeInfo: clearMaze
+      };
     default:
       return state;
   }

--- a/src/reducers/menuReducer.spec.ts
+++ b/src/reducers/menuReducer.spec.ts
@@ -45,20 +45,6 @@ describe("Menu Reducer Tests", () => {
     expect(updatedState).toEqual(expectedState);
   });
 
-  it("Clear Grid Expected State", () => {
-    // const action = {
-    //   type: CLEAR_GRID,
-    //   payload: null
-    // };
-
-    // const updatedState = menuReducer(initialState, action);
-    // const expectedState: MenuState = { ...initialState, isPlaying: true };
-
-    // expect(updatedState).toEqual(expectedState);
-    // Placeholder bc this reducer does not currently update state
-    expect(Math.pow(2, 2)).toEqual(4);
-  });
-
   it("Change Algorithm Expected State", () => {
     const action = {
       type: CHANGE_ALGO,


### PR DESCRIPTION
I cannot stress enough how difficult JetBlue makes it to push using SSH on their WiFi, but we did it. Mile High Commit Club.

TLDR: This commit just links the `clearMaze` action to the `mazeInfo` object, and sets the entire thing to `type: 'wall'` temporarily in place of an empty space object. Once we get one, we can refactor.