### PR TITLE
Feature/update space prop actions

### DIFF
--- a/src/actions/mazeActions/mazeActions.spec.ts
+++ b/src/actions/mazeActions/mazeActions.spec.ts
@@ -5,11 +5,15 @@ import {
   makeWall,
   makeEmpty,
   loadMaze,
+  setPath,
+  setVisited,
   CHANGE_START,
   CHANGE_END,
   MAKE_WALL,
   MAKE_EMPTY,
-  LOAD_MAZE
+  LOAD_MAZE,
+  SET_PATH,
+  SET_VISITED,
 } from "./mazeActions";
 import { initialState, generateMaze } from "../../models/maze/initialState";
 
@@ -28,8 +32,8 @@ describe("Maze Action Tests", () => {
       const expectedActions = [
         {
           type: CHANGE_START,
-          payload: newPos
-        }
+          payload: newPos,
+        },
       ];
       reduxStore.dispatch(handleChangeStart(newPos));
       expect(reduxStore.getActions()).toEqual(expectedActions);
@@ -43,8 +47,8 @@ describe("Maze Action Tests", () => {
       const expectedActions = [
         {
           type: CHANGE_END,
-          payload: newPos
-        }
+          payload: newPos,
+        },
       ];
       reduxStore.dispatch(handleChangeEnd(newPos));
       expect(reduxStore.getActions()).toEqual(expectedActions);
@@ -58,8 +62,8 @@ describe("Maze Action Tests", () => {
       const expectedActions = [
         {
           type: MAKE_WALL,
-          payload: pos
-        }
+          payload: pos,
+        },
       ];
       reduxStore.dispatch(makeWall(pos));
       expect(reduxStore.getActions()).toEqual(expectedActions);
@@ -73,8 +77,8 @@ describe("Maze Action Tests", () => {
       const expectedActions = [
         {
           type: MAKE_EMPTY,
-          payload: pos
-        }
+          payload: pos,
+        },
       ];
       reduxStore.dispatch(makeEmpty(pos));
       expect(reduxStore.getActions()).toEqual(expectedActions);
@@ -88,10 +92,40 @@ describe("Maze Action Tests", () => {
       const expectedActions = [
         {
           type: LOAD_MAZE,
-          payload: { mazeInfo: maze, clearMaze: generateMaze(5, 5, true) }
-        }
+          payload: { mazeInfo: maze, clearMaze: generateMaze(5, 5, true) },
+        },
       ];
       reduxStore.dispatch(loadMaze(maze));
+      expect(reduxStore.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe("Set Path Test", () => {
+    it("Should call SET_PATH action", () => {
+      const coord = { x: 2, y: 2 };
+      const expectedActions = [
+        {
+          type: SET_PATH,
+          payload: coord,
+        },
+      ];
+
+      reduxStore.dispatch(setPath(coord));
+      expect(reduxStore.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  describe("Set Visited Test", () => {
+    it("Should call SET_VISITED action", () => {
+      const coord = { x: 2, y: 2 };
+      const expectedActions = [
+        {
+          type: SET_VISITED,
+          payload: coord,
+        },
+      ];
+
+      reduxStore.dispatch(setVisited(coord));
       expect(reduxStore.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/actions/mazeActions/mazeActions.spec.ts
+++ b/src/actions/mazeActions/mazeActions.spec.ts
@@ -26,7 +26,7 @@ describe("Maze Action Tests", () => {
   });
 
   describe("Change Start Point Test", () => {
-    it("Should dispatch correct action", () => {
+    it("Should call CHANGE_START action", () => {
       const newPos = { x: 1, y: 1 };
 
       const expectedActions = [
@@ -41,7 +41,7 @@ describe("Maze Action Tests", () => {
   });
 
   describe("Change End Point Test", () => {
-    it("Should dispatch correct action", () => {
+    it("Should call CHANGE_END action", () => {
       const newPos = { x: 1, y: 1 };
 
       const expectedActions = [
@@ -56,7 +56,7 @@ describe("Maze Action Tests", () => {
   });
 
   describe("Make Wall Test", () => {
-    it("Should modify redux store", () => {
+    it("Should call MAKE_WALL action", () => {
       const pos = { x: 1, y: 1 };
 
       const expectedActions = [
@@ -71,7 +71,7 @@ describe("Maze Action Tests", () => {
   });
 
   describe("Make Empty Test", () => {
-    it("Should modify redux store", () => {
+    it("Should call MAKE_EMPTY action", () => {
       const pos = { x: 1, y: 1 };
 
       const expectedActions = [
@@ -86,7 +86,7 @@ describe("Maze Action Tests", () => {
   });
 
   describe("Load Maze Test", () => {
-    it("Should modify redux store", () => {
+    it("Should call LOAD_MAZE action", () => {
       const maze = generateMaze(5, 5, false);
 
       const expectedActions = [

--- a/src/actions/mazeActions/mazeActions.ts
+++ b/src/actions/mazeActions/mazeActions.ts
@@ -6,38 +6,54 @@ export const CHANGE_END = "CHANGE_END";
 export const MAKE_WALL = "MAKE_WALL";
 export const MAKE_EMPTY = "MAKE_EMPTY";
 export const LOAD_MAZE = "LOAD_MAZE";
+export const SET_PATH = "SET_PATH";
+export const SET_VISITED = "SET_VISITED";
 
 export const handleChangeStart = (newPos: Coord): AnyAction => {
   return {
     type: CHANGE_START,
-    payload: newPos
+    payload: newPos,
   };
 };
 
 export const handleChangeEnd = (newPos: Coord): AnyAction => {
   return {
     type: CHANGE_END,
-    payload: newPos
+    payload: newPos,
   };
 };
 
 export const makeWall = (coord: Coord): AnyAction => {
   return {
     type: MAKE_WALL,
-    payload: coord
+    payload: coord,
   };
 };
 
 export const makeEmpty = (coord: Coord): AnyAction => {
   return {
     type: MAKE_EMPTY,
-    payload: coord
+    payload: coord,
   };
 };
 
 export const loadMaze = (maze: MazeInfo): AnyAction => {
   return {
     type: LOAD_MAZE,
-    payload: { mazeInfo: maze, clearMaze: generateMaze(5, 5, true) } as Maze
+    payload: { mazeInfo: maze, clearMaze: generateMaze(5, 5, true) } as Maze,
+  };
+};
+
+export const setPath = (coord: Coord): AnyAction => {
+  return {
+    type: SET_PATH,
+    payload: coord,
+  };
+};
+
+export const setVisited = (coord: Coord): AnyAction => {
+  return {
+    type: SET_VISITED,
+    payload: coord,
   };
 };

--- a/src/components/Maze/Maze.tsx
+++ b/src/components/Maze/Maze.tsx
@@ -16,7 +16,7 @@ import { Vector3, MOUSE } from "three";
 const getMazeSize = (mazeInfo: MazeInfo) => {
   return {
     x: mazeInfo[0].length,
-    y: Object.keys(mazeInfo).length
+    y: Object.keys(mazeInfo).length,
   };
 };
 
@@ -33,7 +33,7 @@ const CameraController = () => {
     controls.maxAzimuthAngle = 0;
     controls.minAzimuthAngle = 0;
     controls.maxPolarAngle = 0;
-    
+
     return () => {
       controls.dispose();
     };
@@ -48,7 +48,7 @@ const populateMaze = (props: Props) => {
     handleChangeStart,
     handleChangeEnd,
     makeWall,
-    makeEmpty
+    makeEmpty,
   } = props;
   const { mazeInfo } = props.maze;
   const mazeSize = getMazeSize(mazeInfo);
@@ -87,9 +87,11 @@ interface Props {
   handleChangeEnd: (newPos: Coord) => void;
   makeWall: (coord: Coord) => void;
   makeEmpty: (coord: Coord) => void;
+  setPath: (coord: Coord) => void;
+  setVisited: (coord: Coord) => void;
 }
 
-const Maze: React.FC<Props> = props => {
+const Maze: React.FC<Props> = (props) => {
   return (
     <Canvas
       className="Maze"
@@ -103,10 +105,9 @@ const Maze: React.FC<Props> = props => {
       //   top: 10
       // }}
       camera={{
-        position: new Vector3(0,10,0)
+        position: new Vector3(0, 10, 0),
       }}
     >
-     
       <CameraController />
       <ambientLight />
 

--- a/src/containers/MazeContainer/MazeContainer.tsx
+++ b/src/containers/MazeContainer/MazeContainer.tsx
@@ -7,13 +7,15 @@ import {
   handleChangeStart,
   handleChangeEnd,
   makeWall,
-  makeEmpty
+  makeEmpty,
+  setPath,
+  setVisited,
 } from "../../actions/mazeActions/mazeActions";
 
 const mapStateToProps = (state: RootState) => ({
   maze: state.maze,
   canMoveStart: state.menu.canMoveStart,
-  canMoveEnd: state.menu.canMoveEnd
+  canMoveEnd: state.menu.canMoveEnd,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
@@ -22,7 +24,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       handleChangeStart,
       handleChangeEnd,
       makeWall,
-      makeEmpty
+      makeEmpty,
+      setPath,
+      setVisited,
     },
     dispatch
   );

--- a/src/reducers/mazeReducer/mazeReducer.spec.ts
+++ b/src/reducers/mazeReducer/mazeReducer.spec.ts
@@ -5,7 +5,9 @@ import {
   CHANGE_START,
   CHANGE_END,
   MAKE_WALL,
-  MAKE_EMPTY
+  MAKE_EMPTY,
+  SET_PATH,
+  SET_VISITED,
 } from "../../actions/mazeActions/mazeActions";
 import { Maze } from "../../models/maze";
 import { SpaceTypes } from "../../components/Space/types";
@@ -14,13 +16,13 @@ describe("Maze Reducer Tests", () => {
   it("Clear Grid Expected State", () => {
     const action = {
       type: CLEAR_GRID,
-      payload: null
+      payload: null,
     };
 
     const updatedState = mazeReducer(initialState, action);
     const expectedState: Maze = {
       ...initialState,
-      mazeInfo: initialState.clearMaze
+      mazeInfo: initialState.clearMaze,
     };
 
     expect(updatedState).toEqual(expectedState);
@@ -31,7 +33,7 @@ describe("Maze Reducer Tests", () => {
 
     const action = {
       type: CHANGE_START,
-      payload: newCoord
+      payload: newCoord,
     };
 
     let newMaze = initialState.mazeInfo;
@@ -40,7 +42,7 @@ describe("Maze Reducer Tests", () => {
     const updatedState = mazeReducer(initialState, action);
     const expectedState: Maze = {
       ...initialState,
-      mazeInfo: newMaze
+      mazeInfo: newMaze,
     };
 
     expect(updatedState).toEqual(expectedState);
@@ -51,7 +53,7 @@ describe("Maze Reducer Tests", () => {
 
     const action = {
       type: CHANGE_END,
-      payload: newCoord
+      payload: newCoord,
     };
 
     let newMaze = initialState.mazeInfo;
@@ -60,7 +62,7 @@ describe("Maze Reducer Tests", () => {
     const updatedState = mazeReducer(initialState, action);
     const expectedState: Maze = {
       ...initialState,
-      mazeInfo: newMaze
+      mazeInfo: newMaze,
     };
 
     expect(updatedState).toEqual(expectedState);
@@ -72,7 +74,7 @@ describe("Maze Reducer Tests", () => {
 
     const action = {
       type: MAKE_EMPTY,
-      payload: newCoord
+      payload: newCoord,
     };
 
     let newMaze = initialState.mazeInfo;
@@ -81,7 +83,7 @@ describe("Maze Reducer Tests", () => {
     const updatedState = mazeReducer(initialState, action);
     const expectedState: Maze = {
       ...initialState,
-      mazeInfo: newMaze
+      mazeInfo: newMaze,
     };
 
     expect(updatedState).toEqual(expectedState);
@@ -93,7 +95,7 @@ describe("Maze Reducer Tests", () => {
 
     const action = {
       type: MAKE_WALL,
-      payload: newCoord
+      payload: newCoord,
     };
 
     let newMaze = initialState.mazeInfo;
@@ -102,7 +104,47 @@ describe("Maze Reducer Tests", () => {
     const updatedState = mazeReducer(initialState, action);
     const expectedState: Maze = {
       ...initialState,
-      mazeInfo: newMaze
+      mazeInfo: newMaze,
+    };
+
+    expect(updatedState).toEqual(expectedState);
+  });
+
+  it("Changes a space's property 'path' to true", () => {
+    const coord = { x: 2, y: 2 };
+
+    const action = {
+      type: SET_PATH,
+      payload: coord,
+    };
+
+    let newMaze = initialState.mazeInfo;
+    newMaze[coord.y][coord.x].path = true;
+
+    const updatedState = mazeReducer(initialState, action);
+    const expectedState: Maze = {
+      ...initialState,
+      mazeInfo: newMaze,
+    };
+
+    expect(updatedState).toEqual(expectedState);
+  });
+
+  it("Changes a space's property 'visited' to true", () => {
+    const coord = { x: 2, y: 2 };
+
+    const action = {
+      type: SET_VISITED,
+      payload: coord,
+    };
+
+    let newMaze = initialState.mazeInfo;
+    newMaze[coord.y][coord.x].visited = true;
+
+    const updatedState = mazeReducer(initialState, action);
+    const expectedState: Maze = {
+      ...initialState,
+      mazeInfo: newMaze,
     };
 
     expect(updatedState).toEqual(expectedState);

--- a/src/reducers/mazeReducer/mazeReducer.ts
+++ b/src/reducers/mazeReducer/mazeReducer.ts
@@ -7,17 +7,19 @@ import {
   CHANGE_END,
   MAKE_WALL,
   MAKE_EMPTY,
-  LOAD_MAZE
+  LOAD_MAZE,
+  SET_PATH,
+  SET_VISITED,
 } from "../../actions/mazeActions/mazeActions";
 
 const getMazeSize = (mazeInfo: MazeInfo): Coord => {
   return {
     x: mazeInfo[0].length,
-    y: Object.keys(mazeInfo).length
+    y: Object.keys(mazeInfo).length,
   };
 };
 
-// // Gets the coordinate of either the start or end points
+// Gets the coordinate of either the start or end points
 const getCoord = (
   mazeInfo: MazeInfo,
   spaceType: SpaceTypes.start | SpaceTypes.end
@@ -60,6 +62,18 @@ const changeSpaceType = (
   return newMaze;
 };
 
+const updateSpaceProp = (
+  coord: Coord,
+  mazeInfo: MazeInfo,
+  prop: "path" | "visited"
+) => {
+  let newMaze = mazeInfo;
+
+  newMaze[coord.y][coord.x][prop] = !mazeInfo[coord.y][coord.x][prop];
+
+  return newMaze;
+};
+
 export const mazeReducer = (state = initialState, { type, payload }: any) => {
   switch (type) {
     case CLEAR_GRID:
@@ -69,31 +83,41 @@ export const mazeReducer = (state = initialState, { type, payload }: any) => {
           Object.keys(state.mazeInfo).length,
           state.mazeInfo[0].length,
           true
-        )
+        ),
       };
     case CHANGE_START:
       return {
         ...state,
-        mazeInfo: changeSpaceType(state, payload, SpaceTypes.start)
+        mazeInfo: changeSpaceType(state, payload, SpaceTypes.start),
       };
     case CHANGE_END:
       return {
         ...state,
-        mazeInfo: changeSpaceType(state, payload, SpaceTypes.end)
+        mazeInfo: changeSpaceType(state, payload, SpaceTypes.end),
       };
     case MAKE_WALL:
       return {
         ...state,
-        mazeInfo: changeSpaceType(state, payload, SpaceTypes.wall)
+        mazeInfo: changeSpaceType(state, payload, SpaceTypes.wall),
       };
     case MAKE_EMPTY:
       return {
         ...state,
-        mazeInfo: changeSpaceType(state, payload, SpaceTypes.empty)
+        mazeInfo: changeSpaceType(state, payload, SpaceTypes.empty),
       };
     case LOAD_MAZE:
-      console.log(payload)
-      return payload
+      console.log(payload);
+      return payload;
+    case SET_PATH:
+      return {
+        ...state,
+        mazeInfo: updateSpaceProp(payload, state.mazeInfo, "path"),
+      };
+    case SET_VISITED:
+      return {
+        ...state,
+        mazeInfo: updateSpaceProp(payload, state.mazeInfo, "visited"),
+      };
     default:
       return state;
   }


### PR DESCRIPTION
Adds `setPath` and `setVisited` actions to the maze
Both take a coordinate as an arg and set that property on that corresponding space to the opposite value

#57 