### PR TITLE
changes mesh position to 3 number array

### DIFF
--- a/src/components/Maze/Maze.tsx
+++ b/src/components/Maze/Maze.tsx
@@ -65,7 +65,7 @@ const populateMaze = (props: Props, openSet: Coord[], closedSet: Coord[]) => {
           type={mazeInfo[y][x].type}
           visited={mazeInfo[y][x].visited}
           path={mazeInfo[y][x].path}
-          position={[x, 0, y]}
+          position={{ x, z: 0, y }}
           inOpenSet={includesCoord(openSet, { x, y } as Coord)}
           inClosedSet={includesCoord(closedSet, { x, y } as Coord)}
           key={key}

--- a/src/components/Space/Space.tsx
+++ b/src/components/Space/Space.tsx
@@ -5,7 +5,7 @@ import { SpaceTypes } from "./types";
 
 interface Props {
   type: SpaceTypes;
-  position: number[];
+  position: { x: number; z: number; y: number };
   key: number;
   visited: Boolean;
   path: Boolean;
@@ -39,7 +39,7 @@ const Space: React.FC<Props> = (props) => {
 
   return (
     <mesh
-      position={props.position}
+      position={[props.position.x, props.position.z, props.position.y]}
       onClick={(e) => spaceClicked()}
       onPointerOver={(e) => setHover(true)}
       onPointerOut={(e) => setHover(false)}


### PR DESCRIPTION
for some reason mesh's position property won't take a number array anymore so this converts it to `[number, number, number]`